### PR TITLE
LLM Provider Support - GitHub Models + OpenAI (#9)

### DIFF
--- a/.github/actions/_doctor/dist/index.js
+++ b/.github/actions/_doctor/dist/index.js
@@ -32147,7 +32147,9 @@ on:
         description: 'Sources (Comma Separated)'
         type: string
 
-permissions: {}
+permissions:
+  # Only used when HYALINE_LLM_PROVIDER is set to github-models and HYALINE_LLM_TOKEN is not set
+  models: read
 
 jobs:
   audit:
@@ -32168,7 +32170,7 @@ jobs:
           HYALINE_CONFIG_GITHUB_TOKEN: \${{ secrets.HYALINE_CONFIG_GITHUB_TOKEN }}
           HYALINE_LLM_PROVIDER: \${{ vars.HYALINE_LLM_PROVIDER }}
           HYALINE_LLM_MODEL: \${{ vars.HYALINE_LLM_MODEL }}
-          HYALINE_LLM_TOKEN: \${{ secrets.HYALINE_LLM_TOKEN }}`;
+          HYALINE_LLM_TOKEN: \${{ secrets.HYALINE_LLM_TOKEN || (vars.HYALINE_LLM_PROVIDER == 'github-models' && secrets.GITHUB_TOKEN) }}`;
 }
 
 /**
@@ -32248,7 +32250,7 @@ async function doctor() {
     if (!process.env.HYALINE_LLM_MODEL) {
       envErrors.push('HYALINE_LLM_MODEL not set')
     }
-    if (!process.env.HYALINE_LLM_TOKEN) {
+    if (process.env.HYALINE_LLM_PROVIDER !== 'github-models' && !process.env.HYALINE_LLM_TOKEN) {
       envErrors.push('HYALINE_LLM_TOKEN not set')
     }
     if (envErrors.length != 0) {

--- a/.github/actions/_doctor/src/index.js
+++ b/.github/actions/_doctor/src/index.js
@@ -311,7 +311,9 @@ on:
         description: 'Sources (Comma Separated)'
         type: string
 
-permissions: {}
+permissions:
+  # Only used when HYALINE_LLM_PROVIDER is set to github-models and HYALINE_LLM_TOKEN is not set
+  models: read
 
 jobs:
   audit:
@@ -332,7 +334,7 @@ jobs:
           HYALINE_CONFIG_GITHUB_TOKEN: \${{ secrets.HYALINE_CONFIG_GITHUB_TOKEN }}
           HYALINE_LLM_PROVIDER: \${{ vars.HYALINE_LLM_PROVIDER }}
           HYALINE_LLM_MODEL: \${{ vars.HYALINE_LLM_MODEL }}
-          HYALINE_LLM_TOKEN: \${{ secrets.HYALINE_LLM_TOKEN }}`;
+          HYALINE_LLM_TOKEN: \${{ secrets.HYALINE_LLM_TOKEN || (vars.HYALINE_LLM_PROVIDER == 'github-models' && secrets.GITHUB_TOKEN) }}`;
 }
 
 /**
@@ -412,7 +414,7 @@ async function doctor() {
     if (!process.env.HYALINE_LLM_MODEL) {
       envErrors.push('HYALINE_LLM_MODEL not set')
     }
-    if (!process.env.HYALINE_LLM_TOKEN) {
+    if (process.env.HYALINE_LLM_PROVIDER !== 'github-models' && !process.env.HYALINE_LLM_TOKEN) {
       envErrors.push('HYALINE_LLM_TOKEN not set')
     }
     if (envErrors.length != 0) {

--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -19,7 +19,9 @@ on:
         description: 'Sources (Comma Separated)'
         type: string
 
-permissions: {}
+permissions:
+  # Only used when HYALINE_LLM_PROVIDER is set to github-models and HYALINE_LLM_TOKEN is not set
+  models: read
 
 jobs:
   audit:
@@ -43,4 +45,4 @@ jobs:
           HYALINE_CONFIG_GITHUB_TOKEN: ${{ secrets.HYALINE_CONFIG_GITHUB_TOKEN }}
           HYALINE_LLM_PROVIDER: ${{ vars.HYALINE_LLM_PROVIDER }}
           HYALINE_LLM_MODEL: ${{ vars.HYALINE_LLM_MODEL }}
-          HYALINE_LLM_TOKEN: ${{ secrets.HYALINE_LLM_TOKEN }}
+          HYALINE_LLM_TOKEN: ${{ secrets.HYALINE_LLM_TOKEN || (vars.HYALINE_LLM_PROVIDER == 'github-models' && secrets.GITHUB_TOKEN) }}

--- a/.github/workflows/_check-pr.yml
+++ b/.github/workflows/_check-pr.yml
@@ -15,7 +15,9 @@ on:
         description: 'Configuration Path'
         type: string
 
-permissions: {}
+permissions:
+  # Only used when HYALINE_LLM_PROVIDER is set to github-models and HYALINE_LLM_TOKEN is not set
+  models: read
 
 jobs:
   check-pr:
@@ -38,4 +40,4 @@ jobs:
           HYALINE_GITHUB_TOKEN: ${{ secrets.HYALINE_GITHUB_TOKEN }}
           HYALINE_LLM_PROVIDER: ${{ vars.HYALINE_LLM_PROVIDER }}
           HYALINE_LLM_MODEL: ${{ vars.HYALINE_LLM_MODEL }}
-          HYALINE_LLM_TOKEN: ${{ secrets.HYALINE_LLM_TOKEN }}
+          HYALINE_LLM_TOKEN:  ${{ secrets.HYALINE_LLM_TOKEN || (vars.HYALINE_LLM_PROVIDER == 'github-models' && secrets.GITHUB_TOKEN) }}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Generated and maintained by the Doctor workflow at `.github/workflows/_manual_ex
 ### Run Audit
 Generated and maintained by the Doctor workflow at `.github/workflows/_manual_audit.yml` based on configurations in the `audits/` directory. Provides a dropdown interface to select and run a specific audit.
 
+Note: This workflow requests `models: read` permissions for the action's `GITHUB_TOKEN` in order to allow access to [GitHub Models](https://github.com/features/models). However, GitHub Models access is only used when the `HYALINE_LLM_PROVIDER` is configured to be `github-models` and `HYALINE_LLM_TOKEN` isn't set.
+
 **Usage:** Run manually via workflow dispatch to run a specific audit. The dropdown options are automatically updated by the Doctor workflow.
 
 **Inputs:**
@@ -74,6 +76,8 @@ The following workflows are used by the GitHub App for internal purposes. Note t
 
 ### [_Audit](.github/workflows/_audit.yml)
 Audits documentation against configured rules. Requires that the `_current-documentation` artifact exists (created by the `_merge` workflow) to audit against.
+
+Note: This workflow requests `models: read` permissions for the action's `GITHUB_TOKEN` in order to allow access to [GitHub Models](https://github.com/features/models). However, GitHub Models access is only used when the `HYALINE_LLM_PROVIDER` is configured to be `github-models` and `HYALINE_LLM_TOKEN` isn't set.
 
 **Usage:** Run manually via workflow dispatch to audit documentation quality against a configuration.
 
@@ -95,6 +99,8 @@ The workflow supports the following inputs (one of audit, repo, site, or config 
 Checks a pull request for documentation updates. Requires that the `_current-documentation` artifact exists (created by the `_merge` workflow) to check against.
 
 **Usage:** Run automatically by the Hyaline GitHub App when a PR is ready for review and changes are made to the PR. Can also be run manually via workflow dispatch.
+
+Note: This workflow requests `models: read` permissions for the action's `GITHUB_TOKEN` in order to allow access to [GitHub Models](https://github.com/features/models). However, GitHub Models access is only used when the `HYALINE_LLM_PROVIDER` is configured to be `github-models` and `HYALINE_LLM_TOKEN` isn't set.
 
 **Inputs:**
 The workflow supports the following inputs:


### PR DESCRIPTION
# Purpose
The purpose of this change is to add support for the GitHub models and OpenAI provider. See: https://github.com/appgardenstudios/hyaline/issues/281

# Changes
- Update the _check-pr, _audit, and _manual-audit workflows to request models: read permissions and pass in GITHUB_TOKEN as the LLM_PROVIDER_TOKEN
- Update README to call out the `models: read` permission for the relevant workflows

# Testing
1. Change the default branch to 281-upstream
2. Change the HYALINE_LLM_PROVIDER to be `github-models`
3. Change the HYALINE_LLM_MODEL` to be a supported GITHUB model like `openai/gpt-4o`
4. Add an audit config
5. Run and audit and ensure it completes successfully and the output looks correct
6. Run a manual audit and ensure it completes successfully and the output looks correct
7. Manually run a check PR and ensure it completes successfully and the output looks correct
