### PR TITLE
Github App - Update Hyaline Workflow (#25)

### DIFF
--- a/.github/actions/_doctor/action.yml
+++ b/.github/actions/_doctor/action.yml
@@ -1,5 +1,9 @@
 name: 'Action - Doctor'
 description: 'Doctor'
+inputs:
+  upstream:
+    description: 'Upstream repository URL'
+    required: true
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/.github/actions/_doctor/src/index.js
+++ b/.github/actions/_doctor/src/index.js
@@ -10,6 +10,8 @@ const hyalineOctokit = github.getOctokit(hyalineGitHubToken);
 const configGitHubToken = process.env.HYALINE_CONFIG_GITHUB_TOKEN || '';
 const configOctokit = github.getOctokit(configGitHubToken);
 
+const upstreamUrl = core.getInput('upstream', { required: true });
+
 /**
  * Get the llm block of the hyaline config.
  *
@@ -370,6 +372,62 @@ async function validateConfigs(directory) {
 }
 
 /**
+ * Get the default branch for a remote
+ *
+ * @param {string} remoteName - The name of the remote (e.g., 'origin', 'upstream')
+ * @returns {Promise<string>} - The default branch name
+ */
+async function getDefaultBranch(remoteName) {
+  const remoteOutput = await exec.getExecOutput('git', ['remote', 'show', remoteName]);
+  const match = remoteOutput.stdout.match(/HEAD branch: (.+)/);
+  return match ? match[1].trim() : 'main';
+}
+
+/**
+ * Check for upstream updates
+ *
+ * @returns {Promise<{hasUpdates: boolean, error: string|null}>}
+ */
+async function checkUpstreamUpdates() {
+  try {
+    console.log(`Checking for updates from upstream: ${upstreamUrl}`);
+
+    // Add upstream remote
+    await exec.exec('git', ['remote', 'add', 'upstream', upstreamUrl]);
+
+    // Fetch from upstream
+    console.log('Fetching from upstream...');
+    await exec.exec('git', ['fetch', 'upstream']);
+
+    // Get default branches
+    const originDefault = await getDefaultBranch('origin');
+    const upstreamDefault = await getDefaultBranch('upstream');
+    console.log(`Origin default branch: ${originDefault}`);
+    console.log(`Upstream default branch: ${upstreamDefault}`);
+
+    // Get current upstream commit
+    const upstreamCommitOutput = await exec.getExecOutput('git', ['rev-parse', `upstream/${upstreamDefault}`]);
+    const upstreamCommit = upstreamCommitOutput.stdout.trim();
+    console.log(`Upstream commit: ${upstreamCommit}`);
+
+    // Check if upstream commit is an ancestor of origin commit
+    const mergeBaseOutput = await exec.getExecOutput('git', ['merge-base', `upstream/${upstreamDefault}`, `origin/${originDefault}`], { ignoreReturnCode: true });
+    if (mergeBaseOutput.exitCode !== 0) {
+      throw new Error(`Failed to compare upstream and origin branches. Please ensure the "Install Hyaline" workflow has been run. Error: ${mergeBaseOutput.stderr}`);
+    }
+    const mergeBase = mergeBaseOutput.stdout.trim();
+
+    const hasUpdates = mergeBase !== upstreamCommit;
+    console.log(hasUpdates ? 'Updates available from upstream' : 'No updates available - repository is up to date');
+
+    return { hasUpdates, error: null };
+  } catch (error) {
+    console.error('Failed to check upstream updates:', error);
+    return { hasUpdates: false, error: error.message };
+  }
+}
+
+/**
  * Get a PR Body based on changes and validation errors
  * 
  * @param {Array<string>} changes 
@@ -400,7 +458,13 @@ function getPRBody(changes, validationErrors = []) {
 }
 
 async function doctor() {
+  let prURL = null;
+  let upstreamStatus;
+
   try {
+    // Check for upstream updates
+    upstreamStatus = await checkUpstreamUpdates();
+
     // Check Secrets and Env Vars
     const envErrors = [];
     if (!process.env.HYALINE_GITHUB_TOKEN) {
@@ -511,13 +575,27 @@ async function doctor() {
           title: 'Doctor - Configuration Update',
           body: getPRBody(changes, validationErrors),
         });
-        const prURL = `https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/pull/${result.data.number}`;
+        prURL = `https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/pull/${result.data.number}`;
         console.log(`Created PR ${prURL}`);
       }
     }
 
-    console.log('Doctor Complete');
+    // Add annotations
+    if (prURL) {
+      core.notice(`Doctor submitted a PR for your review: ${prURL}`);
+    } else {
+      core.notice('Doctor did not find any configuration issues.');
+    }
 
+    if (upstreamStatus.error) {
+      core.warning(`Doctor could not check if hyaline is outdated: ${upstreamStatus.error}.`);
+    } else if (upstreamStatus.hasUpdates) {
+      core.notice('Hyaline is outdated. Consider running the "Update Hyaline" workflow.');
+    } else {
+      core.notice('Hyaline is up-to-date.');
+    }
+
+    console.log('Doctor Complete');
   } catch (error) {
     core.error(error);
     throw error;

--- a/.github/actions/_update-hyaline/README.md
+++ b/.github/actions/_update-hyaline/README.md
@@ -1,0 +1,23 @@
+# _update-hyaline
+The `_update-hyaline` action is a composite action that updates the Hyaline configuration repository by merging changes from an upstream repository.
+
+This action performs the following tasks:
+- Adds and fetches from the upstream repository
+- Determines the default branches for both origin and upstream
+- Checks if updates are available by comparing commits
+- Merges upstream changes into the local repository (with optional unrelated history connection)
+- Pushes the updated changes back to the origin repository
+- Annotates the workflow run with the results of running update
+
+## Usage
+This action can be run on `ubuntu-latest` and `macos-latest` (and should work on `windows-latest`) GitHub Actions runners.
+
+For a usage example, see [_update-hyaline.yml](../../workflows/_update-hyaline.yml).
+
+## Inputs
+
+### `upstream`
+**Required** The upstream repository URL to fetch updates from.
+
+### `connect_upstream_history`
+**Optional** Whether to connect upstream history using `--allow-unrelated-histories`. Usually only set to `true` during initial installation. Default: `false`.

--- a/.github/actions/_update-hyaline/action.yml
+++ b/.github/actions/_update-hyaline/action.yml
@@ -1,0 +1,129 @@
+name: 'Action - Update Hyaline'
+description: 'Update Hyaline from upstream repository'
+inputs:
+  upstream:
+    description: 'Upstream repository URL'
+    required: true
+  connect_upstream_history:
+    description: 'Whether to connect upstream history. Usually only `true` during installation.'
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Git Configuration
+      shell: bash
+      run: |
+        git config --global user.name "Hyaline"
+        git config --global user.email "hyaline-bot@users.noreply.github.com"
+
+    - name: Setup Upstream Remote
+      shell: bash
+      run: git remote add upstream "${{ inputs.upstream }}"
+
+    - name: Fetch Upstream Changes
+      shell: bash
+      run: |
+        echo "Fetching from upstream..."
+        git fetch upstream
+
+    - name: Get Default Branches
+      shell: bash
+      id: branches
+      run: |
+        # Get origin default branch
+        origin_default=$(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
+        echo "origin-default=$origin_default" >> $GITHUB_OUTPUT
+        
+        # Get upstream default branch
+        upstream_default=$(git remote show upstream | grep "HEAD branch" | sed 's/.*: //')
+        echo "upstream-default=$upstream_default" >> $GITHUB_OUTPUT
+        
+        echo "Origin default branch: $origin_default"
+        echo "Upstream default branch: $upstream_default"
+
+    - name: Check for Updates
+      shell: bash
+      id: check-updates
+      run: |
+        if [ "${{ inputs.connect_upstream_history }}" = "true" ]; then
+          echo "has-updates=true" >> $GITHUB_OUTPUT
+          echo "Connecting upstream history - forcing update"
+        else
+          origin_branch="${{ steps.branches.outputs.origin-default }}"
+          upstream_branch="${{ steps.branches.outputs.upstream-default }}"
+
+          # Checkout origin default branch
+          git checkout "$origin_branch"
+
+          # Get current upstream commit
+          upstream_commit=$(git rev-parse "upstream/$upstream_branch")
+          echo "Upstream commit: $upstream_commit"
+
+          # Check if upstream has updates that origin doesn't have
+          # If merge-base of upstream and origin equals upstream commit, then origin contains all upstream changes
+          merge_base=$(git merge-base "upstream/$upstream_branch" "origin/$origin_branch")
+
+          if [ "$merge_base" = "$upstream_commit" ]; then
+            echo "has-updates=false" >> $GITHUB_OUTPUT
+            echo "No updates available - repository is already up to date"
+          else
+            echo "has-updates=true" >> $GITHUB_OUTPUT
+            echo "Updates available"
+          fi
+        fi
+
+    - name: Merge Upstream Changes
+      shell: bash
+      if: steps.check-updates.outputs.has-updates == 'true'
+      run: |
+        origin_branch="${{ steps.branches.outputs.origin-default }}"
+        upstream_branch="${{ steps.branches.outputs.upstream-default }}"
+
+        # Checkout origin default branch
+        git checkout "$origin_branch"
+
+        echo "Merging upstream/$upstream_branch into $origin_branch..."
+
+        merge_flags="--no-edit"
+        if [ "${{ inputs.connect_upstream_history }}" = "true" ]; then
+          merge_flags="$merge_flags --allow-unrelated-histories"
+        fi
+
+        if git merge "upstream/$upstream_branch" $merge_flags; then
+          echo "Merge successful"
+        else
+          exit 1
+        fi
+
+    - name: Push Changes
+      shell: bash
+      if: steps.check-updates.outputs.has-updates == 'true'
+      run: |
+        origin_branch="${{ steps.branches.outputs.origin-default }}"
+        
+        echo "Pushing changes to origin/$origin_branch..."
+        
+        if git push origin "$origin_branch"; then
+          echo "Push successful"
+        else
+          exit 1
+        fi
+
+    - name: Annotate Success
+      shell: bash
+      if: steps.check-updates.outputs.has-updates == 'true'
+      run: |
+        echo "::notice::Hyaline was successfully updated from upstream"
+
+    - name: Annotate No Updates
+      shell: bash
+      if: steps.check-updates.outputs.has-updates == 'false'
+      run: |
+        echo "::notice::No updates available - Hyaline is already up to date"
+
+    - name: Annotate Failure
+      shell: bash
+      if: failure()
+      run: |
+        echo "::error::Failed to update Hyaline from upstream. You may need to manually update Hyaline. See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork#syncing-a-fork-branch-from-the-command-line"

--- a/.github/apps/_hyaline/README.md
+++ b/.github/apps/_hyaline/README.md
@@ -1,18 +1,18 @@
 # Hyaline GitHub App
-The Hyaline GitHub App listens to Pull Request webhook events from configured repositories and triggers [_Check PR](../../workflows/_check-pr.yml) and [_Extract](../../workflows/_extract.yml) workflows in the forked configuration repository.
+The Hyaline GitHub App listens to Pull Request webhook events from configured repositories and triggers [_Check PR](../../workflows/_check-pr.yml) and [_Extract](../../workflows/_extract.yml) workflows in the your `hyaline-github-app-config` repo instance.
 
 The GitHub App uses [Hono](https://hono.dev/), which is a batteries included JavaScript runtime that can be deployed to a variety of [platforms](https://hono.dev/docs/getting-started/basic).
 
 ## GitHub App Installation
 
-### 1. Fork Config
-Fork the [appgardenstudios/hyaline-github-app-config](https://github.com/appgardenstudios/hyaline-github-app-config) repository into your org or personal account. You will need to set this up as described in the main [README.md](../../../README.md).
+### 1. Create a `hyaline-github-app-config` repo instance
+Go to the [appgardenstudios/hyaline-github-app-config](https://github.com/appgardenstudios/hyaline-github-app-config) repository, click "Use this template," and create a new repository in your org or personal account. You will need to set this up as described in the main [README.md](../../../README.md).
 
 ### 2. Create GitHub App
-Sign in to GitHub and create a new GitHub App in your organization or personal account. It MUST belong to the same account as the `hyaline-github-app-config` repository you forked above. You will need to supply/configure the following when creating the app:
+Sign in to GitHub and create a new GitHub App in your organization or personal account. It MUST belong to the same account as the `hyaline-github-app-config` repository you created above. You will need to supply/configure the following when creating the app:
 
 - **GitHub App name** - Choose a valid name for this app (e.g. `hyaline-github-app-<my-org>`)
-- **Homepage URL** - Use your own website or the URL for your forked configuration repo from Step 0
+- **Homepage URL** - Use your own website or the URL for your `hyaline-github-app-config` repo instance from Step 1
 - **Webhook > Active** - Uncheck this for now (this will be configured in Step 4)
 - **Permissions** - Leave this empty for now (this will be configured in Step 4)
 - **Where can this GitHub App be installed?** - Leave this set to "Only on this account"
@@ -33,7 +33,7 @@ Choose your desired platform and configure hono to deploy it. You will need to e
 - **GITHUB_APP_ID** - The `App ID` from Step 2 above.
 - **GITHUB_PRIVATE_KEY** - The `Private Key` from Step 2 above.
 - **WEBHOOK_SECRET** - A string used to verify that the caller is indeed GitHub. We recommend using a new UUIDv4.
-- **HYALINE_CONFIG_REPO** - (Optional) The name of the forked configuration repository. If not set `hyaline-github-app-config` will be used.
+- **HYALINE_CONFIG_REPO** - (Optional) The name of your `hyaline-github-app-config` repo instance. If not set `hyaline-github-app-config` will be used.
 
 Note that the endpoint will need to be reachable from GitHub's webhook servers (hooks in [GitHub's meta API endpoint](https://api.github.com/meta)).
 
@@ -53,7 +53,7 @@ Configure the GitHub App to send events to the deployed app. Do the following:
 - Check the **Subscribe to events > Pull request** option
 
 ### 5. Install GitHub App
-Go to your organization or personal account settings and install the GitHub app for the repositories you want to use Hyaline with. You will need to give it access to at least the `hyaline-github-app-config` repo you forked so that the GitHub app can use the configuration you set up. Once installed you should see webhook calls being dispatched.
+Go to your organization or personal account settings and install the GitHub app for the repositories you want to use Hyaline with. You will need to give it access to at least your `hyaline-github-app-config` repo instance so that the GitHub app can use the configuration you set up. Once installed you should see webhook calls being dispatched.
 
 ## Running Locally
 To run the app locally you will need a working installed GitHub App (follow the instructions above to install).

--- a/.github/workflows/_install-hyaline.yml
+++ b/.github/workflows/_install-hyaline.yml
@@ -1,4 +1,4 @@
-name: Doctor
+name: Install Hyaline
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
 permissions: {}
 
 jobs:
-  doctor:
+  update:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -14,6 +14,22 @@ jobs:
         with:
           token: ${{ secrets.HYALINE_CONFIG_GITHUB_TOKEN }}
           fetch-depth: 0
+      - name: Update Hyaline
+        uses: ./.github/actions/_update-hyaline
+        with:
+          upstream: https://github.com/appgardenstudios/hyaline-github-app-config.git
+          connect_upstream_history: true
+  doctor:
+    runs-on: ubuntu-latest
+    needs: update
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HYALINE_CONFIG_GITHUB_TOKEN }}
+          fetch-depth: 0
+          # Make sure we grab the latest from the default branch in case `update` pushed changes
+          ref: ${{ github.event.repository.default_branch }}
       - name: Setup Hyaline CLI
         uses: appgardenstudios/hyaline-actions/setup@v1
       - name: Doctor

--- a/.github/workflows/_update-hyaline.yml
+++ b/.github/workflows/_update-hyaline.yml
@@ -1,0 +1,20 @@
+name: Update Hyaline
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.HYALINE_CONFIG_GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: Update Hyaline
+        uses: ./.github/actions/_update-hyaline
+        with:
+          upstream: https://github.com/appgardenstudios/hyaline-github-app-config.git

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Configuration for the Hyaline GitHub App
 The following workflows are available.
 
 ### [Doctor](.github/workflows/_doctor.yml)
-Maintains the configuration repository by discovering repositories, generating configurations, validating existing configs, and creating pull requests with updates.
+Maintains the configuration repository by checking for updates, discovering repositories, generating configurations, validating existing configs, and creating pull requests with updates.
 
 **Usage:** Run manually via workflow dispatch to keep the repository up to date.
 
@@ -55,6 +55,26 @@ Generated and maintained by the Doctor workflow at `.github/workflows/_manual_ex
 
 **Artifacts produced:**
 - `_extracted-documentation` - Contains `documentation.db` with the extracted documentation
+
+### [Install Hyaline](.github/workflows/_install-hyaline.yml)
+Performs installation for the Hyaline GitHub App, including updating hyaline and running the Doctor to initialize configuration.
+
+**Usage:** Run manually via workflow dispatch to install the Hyaline GitHub App configuration. This is typically only used during initial setup.
+
+**Inputs:** None
+
+**Artifacts produced:** None (updates the repository directly and triggers the Doctor)
+
+### [Update Hyaline](.github/workflows/_update-hyaline.yml)
+Updates the configuration repository from the upstream Hyaline GitHub App configuration repository (i.e. https://github.com/appgardenstudios/hyaline-github-app-config).
+
+**Usage:** Run manually via workflow dispatch to update the Hyaline GitHub App configuration from the upstream repository.
+
+**Inputs:** None
+
+**Artifacts produced:** None (updates the repository directly)
+
+**More info:** See [_update-hyaline action](.github/actions/_update-hyaline)
 
 ### Run Audit
 Generated and maintained by the Doctor workflow at `.github/workflows/_manual_audit.yml` based on configurations in the `audits/` directory. Provides a dropdown interface to select and run a specific audit.
@@ -142,7 +162,7 @@ Merges new extracted documentation databases into the current documentation data
 ## Apps
 
 ### [Hyaline GitHub App](.github/apps/_hyaline/)
-The Hyaline GitHub App listens to Pull Request webhook events from configured repositories and triggers [_Check PR](./.github/workflows/_check-pr.yml) and [_Extract](./.github/workflows/_extract.yml) workflows in the forked configuration repository.
+The Hyaline GitHub App listens to Pull Request webhook events from configured repositories and triggers [_Check PR](./.github/workflows/_check-pr.yml) and [_Extract](./.github/workflows/_extract.yml) workflows in your `hyaline-github-app-config` repo instance.
 
 Note that it is only necessary to deploy and use this app if you are unable to use the public Hyaline GitHub App available on GitHub.
 
@@ -156,21 +176,19 @@ Note that it is only necessary to deploy and use this app if you are unable to u
 Note that the Hyaline GitHub App will trigger workflows in the configuration repository located in your organization or personal account, meaning that you stay in control of your configuration and data. If you wish you can also run your own copy of the Hyaline GitHub app (located in the [configuration repository](https://github.com/appgardenstudios/hyaline-github-app-config)) to prevent any data whatsoever from leaving your organization and being sent to us.
 
 ### 1. Create GitHub App Config Repo
-All of your configuration for the Hyaline GitHub App will live in a single repository in your organization or personal account. The easiest way to set this up is to fork the [hyaline-github-app-config](https://github.com/appgardenstudios/hyaline-github-app-config) repository into the organization or personal account that you will install the GitHub App into.
+All of your configuration for the Hyaline GitHub App will live in a single repository in your organization or personal account. The easiest way to set this up is to go to the [hyaline-github-app-config](https://github.com/appgardenstudios/hyaline-github-app-config) repository, click "Use this template," and create a new repository called `hyaline-github-app-config` in the organization or personal account that you will install the GitHub App into.
 
-Fork (or otherwise clone/push) the [hyaline-github-app-config](https://github.com/appgardenstudios/hyaline-github-app-config) into your organization or personal account. Note that the repository name MUST remain `hyaline-github-app-config` in order to use the hosted version of the Hyaline GitHub App.
+Create from template (or otherwise clone/push) the [hyaline-github-app-config](https://github.com/appgardenstudios/hyaline-github-app-config) repository into your organization or personal account. Note that the repository name MUST remain `hyaline-github-app-config` in order to use the hosted version of the Hyaline GitHub App.
 
-Please see GitHub's documentation on [how to fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository).
-
-Note that we ask that you fork the configuration repository to make it easy to pull in updated documentation, new features, and bug fixes from the source repository using [GitHub's sync functionality](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+Please see GitHub's documentation on [how to create a repository from a template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).
 
 ### 2. Setup Secrets and Environment Variables
-You will need to setup the following secrets and environment variables in the forked `hyaline-github-app-config` repository.
+You will need to setup the following secrets and environment variables in your `hyaline-github-app-config` repo instance.
 
-Note: Since Hyaline uses GitHub Personal Access Tokens (PATs) issued by you to act on your behalf, it is recommended to create a dedicated service account to use when issuing PATs. This is so that the comments made by Hyaline on pull requests will use the service account name instead of an individual's name. The service account will need read access to each repository that the GitHub App has access to, and write access to the forked `hyaline-github-app-config` repository.
+Note: Since Hyaline uses GitHub Personal Access Tokens (PATs) issued by you to act on your behalf, it is recommended to create a dedicated service account to use when issuing PATs. This is so that the comments made by Hyaline on pull requests will use the service account name instead of an individual's name. The service account will need read access to each repository that the GitHub App has access to, and write access to your `hyaline-github-app-config` repo instance.
 
 #### Secrets
-The following repository secrets should be created in the forked `hyaline-github-app-config` repo:
+The following repository secrets should be created in your `hyaline-github-app-config` repo instance:
 
 **HYALINE_GITHUB_TOKEN** - A GitHub Personal Access Token (PAT) that will be used to extract repo documentation and comment on pull requests (this will be referenced as the value for `github.token` and `extract.crawler.options.auth.password` in the configs via environment substitution). This token should be scoped to the repositories that Hyaline will be extracting documentation from or checking PRs for. It will need to have the following permissions:
 - Metadata: Read - Required by GitHub for all PATs
@@ -179,7 +197,7 @@ The following repository secrets should be created in the forked `hyaline-github
 
 Note that this PAT will include access to public repositories in the organization or personal account as well as any private repositories that were explicitly added to the scope of the PAT.
 
-**HYALINE_CONFIG_GITHUB_TOKEN** - A GitHub Personal Access Token (PAT) that will be used to manage the GitHub App's configuration. This token should be scoped to the forked `hyaline-github-app-config` repository. It will need to have the following permissions:
+**HYALINE_CONFIG_GITHUB_TOKEN** - A GitHub Personal Access Token (PAT) that will be used to manage the GitHub App's configuration. This token should be scoped to your `hyaline-github-app-config` repo instance. It will need to have the following permissions:
 - Metadata: Read - Required by GitHub for all PATs
 - Actions: Read and Write - Used by extract workflows in the config to trigger the merge workflow once extraction is complete
 - Contents: Read and Write - Used to clone the configuration in workflows and used by the doctor to push suggested changes to a branch for review
@@ -189,27 +207,27 @@ Note that this PAT will include access to public repositories in the organizatio
 **HYALINE_LLM_TOKEN** - An LLM provider API token used in auditing and checking PRs. This will need to come from the LLM provider and will be referenced as the value for `llm.key` in the configs (using environment substitution).
 
 #### Environment Variables
-The following repository variables should be created in the forked `hyaline-github-app-config` repo:
+The following repository variables should be created in your `hyaline-github-app-config` repo instance:
 
 **HYALINE_LLM_PROVIDER** - The LLM provider to be used. This will be referenced as the value for `llm.provider` in the configs (using environment substitution). Please see [configuration reference](https://www.hyaline.dev/documentation/reference/config/) for supported values.
 
 **HYALINE_LLM_MODEL** - The LLM model to be used. This will be referenced as the value for `llm.provider` in the configs (using environment substitution). Please see [configuration reference](https://www.hyaline.dev/documentation/reference/config/) for supported values.
 
-### 3. Run Doctor
-To bootstrap the repository in preparation for the Github App installation you will need to run the `Doctor` workflow and review/edit/merge the generated pull request.
+### 3. Run Install
+To bootstrap the repository in preparation for the Github App installation you will need to run the `Install` workflow and review/edit/merge the generated pull request.
 
-Manually trigger the `Doctor` workflow in the forked `hyaline-github-app-config` repository and ensure that it completes successfully. It should generate a pull request with a set of suggested changes and configuration updates based on the repositories in scope of the `HYALINE_GITHUB_TOKEN` generated above.
+Manually trigger the `Install` workflow in your `hyaline-github-app-config` repo instance and ensure that it completes successfully. It should generate a pull request with a set of suggested changes and configuration updates based on the repositories in scope of the `HYALINE_GITHUB_TOKEN` generated above.
 
-### 4. Review/Merge Doctor PR
-Review (editing as necessary) and merge the pull request generated by the doctor to the default (`main`) branch. You can view [how to extract documentation](https://www.hyaline.dev/documentation/how-to/extract-documentation/) and [how to check pull request](https://www.hyaline.dev/documentation/how-to/check-pull-request/) for more detail.
+### 4. Review/Merge Install PR
+Review (editing as necessary) and merge the pull request generated by the `Install` workflow to the default (`main`) branch. You can view [how to extract documentation](https://www.hyaline.dev/documentation/how-to/extract-documentation/) and [how to check pull request](https://www.hyaline.dev/documentation/how-to/check-pull-request/) for more detail.
 
 Note that you can explicitly disable unwanted extractions or checks by adding `disabled: true` to the `extract` or `check` section of the configuration (see [configuration reference](https://www.hyaline.dev/documentation/reference/config/) for more details).
 
 ### 5. Run Extract All
-Manually trigger the `Extract All` workflow in the forked `hyaline-github-app-config` repository and ensure that it completes successfully. This will run an extract on all configured repositories and merge the documentation together into a single current data set for use in audits and checks.
+Manually trigger the `Extract All` workflow in your `hyaline-github-app-config` repo instance and ensure that it completes successfully. This will run an extract on all configured repositories and merge the documentation together into a single current data set for use in audits and checks.
 
 ### 6. Install GitHub App
-Install the [Hyaline GitHub App (hyaline.dev)](https://github.com/apps/hyaline-dev) into your organization or personal account. Only grant it access to repositories that you want Hyaline to extract and check pull requests on in addition to the forked `hyaline-github-app-config` repository.
+Install the [Hyaline GitHub App (hyaline.dev)](https://github.com/apps/hyaline-dev) into your organization or personal account. Only grant it access to repositories that you want Hyaline to extract and check pull requests on in addition to your `hyaline-github-app-config` repo instance.
 
 ### 7. Verify Installation
-You can verify the installation of the GitHub App by opening a non-draft PR in one of the repositories in your organization. Once you do you should see the workflow `_Check PR` kicked off in the forked `hyaline-github-app-config` repository and a comment on the pull request with Hyaline's documentation update recommendations. Then, once the pull request is merged, you should see a corresponding workflow run of `_Extract` followed by a workflow run of `_Merge` in the forked `hyaline-github-app-config` repository.
+You can verify the installation of the GitHub App by opening a non-draft PR in one of the repositories in your organization. Once you do you should see the workflow `_Check PR` kicked off in your `hyaline-github-app-config` repo instance and a comment on the pull request with Hyaline's documentation update recommendations. Then, once the pull request is merged, you should see a corresponding workflow run of `_Extract` followed by a workflow run of `_Merge` in your `hyaline-github-app-config` repo instance.


### PR DESCRIPTION
# Purpose
The purpose of this change is to add an "install" and "update" workflow to be used to setup and sync config repo instances, instead of forking. See: https://github.com/appgardenstudios/hyaline/issues/314

# Changes
- Added an "Update" workflow and action that merge and push changes from upstream config repos
- Updated the "Doctor" so that it will check for updates
- Added an "Install" workflow to be run at first setup, which calls "Update" and "Doctor" actions
- Updated documentation

# Testing
- Change the default branch to 314
- Enable creating from templates
- Create a new repo from template
- Run "Install"
- Run "Update"
- Run "Doctor"
- Play around with making changes in 314 or the repo instance and running "Update" and "Doctor"